### PR TITLE
Update daemonset.yaml

### DIFF
--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -20,6 +20,12 @@ spec:
       annotations: {{ toYaml .Values.node.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+    {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+    {{- end }}
       nodeSelector:
         beta.kubernetes.io/os: linux
         {{- with .Values.nodeSelector }}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This is a bug fix

**What is this PR about? / Why do we need it?**
imagePullSecrets variable is present in the values.yaml but not use in the daemonset.yaml so using a private registry with this helm chart will never work

**What testing is done?** 
I used a private nexus repository and set the value for the image pull secrets like this : 
imagePullSecrets: 
  - aws-efs-csi-driver-pullsecret
